### PR TITLE
Add missing fields to match up to 1.2.1 format + parsing fix

### DIFF
--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -340,6 +340,8 @@ class TmxGroup
 
 class TmxBaseLayer
 {
+  /** Unique ID of the layer. Each layer that added to a map gets a unique id. Even if a layer is deleted, no layer ever gets the same ID. Can not be changed in Tiled. (since Tiled 1.2) */
+  public var id:Int;
   /** The name of the layer. */
   public var name:String;
   /** The x coordinate of the layer in tiles. Defaults to 0 and can no longer be changed in Tiled Qt. (Except ImageLayer) */
@@ -361,9 +363,10 @@ class TmxBaseLayer
   
   public var properties:TmxProperties;// Map<String, String>;
   
-  public function new(name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
+  public function new(id:Int, name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
     width:Null<Int>, height:Null<Int>, opacity:Null<Float>, visible:Bool, properties:TmxProperties)
   {
+    this.id = id;
     this.name = name;
     this.x = x;
     this.y = y;
@@ -388,10 +391,10 @@ class TmxImageLayer extends TmxBaseLayer
   @:optional public var image:TmxImage;
   
   public function new(image:TmxImage,
-    name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
+    id:Int, name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
     width:Null<Int>, height:Null<Int>, opacity:Null<Float>, visible:Bool, properties:TmxProperties)
   {
-    super(name, x, y, offsetX, offsetY, width, height, opacity, visible, properties);
+    super(id, name, x, y, offsetX, offsetY, width, height, opacity, visible, properties);
     this.image = image;
   }
 }
@@ -402,10 +405,10 @@ class TmxTileLayer extends TmxBaseLayer
   @:optional public var data:TmxData;
   
   public function new(data:TmxData,
-    name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
+    id:Int, name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
     width:Null<Int>, height:Null<Int>, opacity:Null<Float>, visible:Bool, properties:TmxProperties)
   {
-    super(name, x, y, offsetX, offsetY, width, height, opacity, visible, properties);
+    super(id, name, x, y, offsetX, offsetY, width, height, opacity, visible, properties);
     this.data = data;
   }
 }
@@ -520,10 +523,10 @@ class TmxObjectGroup extends TmxBaseLayer
   public var objects:Array<TmxObject>;
   
   public function new(drawOrder:TmxObjectGroupDrawOrder, objects:Array<TmxObject>, color:Null<Int>, 
-    name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
+    id:Int, name:String, x:Null<Float>, y:Null<Float>, offsetX:Null<Int>, offsetY:Null<Int>,
     width:Null<Int>, height:Null<Int>, opacity:Null<Float>, visible:Bool, properties:TmxProperties)
   {
-    super(name, x, y, offsetX, offsetY, width, height, opacity, visible, properties);
+    super(id, name, x, y, offsetX, offsetY, width, height, opacity, visible, properties);
     this.color = color;
     this.drawOrder = drawOrder;
     this.objects = objects;

--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -46,6 +46,8 @@ class TmxMap
 {
   /** The TMX format version, generally 1.0. */
   public var version:String;
+  /** The Tiled version used to save the file (since Tiled 1.0.1). May be a date (for snapshot builds). */
+  public var tiledVersion:String;
   /** Map orientation. */
   public var orientation:TmxOrientation;
   /** The map width in tiles. */

--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -320,6 +320,8 @@ enum TmxLayer
 @:structInit
 class TmxGroup
 {
+  /** Unique ID of the layer. Each layer that added to a map gets a unique id. Even if a layer is deleted, no layer ever gets the same ID. Can not be changed in Tiled. (since Tiled 1.2) */
+  @:optional public var id:Int;
   /** The name of the group layer. */
   public var name:String;
   /** Rendering offset of the group layer in pixels. Defaults to 0. */

--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -83,6 +83,10 @@ class TmxMap
   /** Stores the next available ID for new objects. This number is stored to prevent reuse of the same ID after objects have been removed. (since 0.11) */
   @:optional public var nextObjectId:Int;
   
+  /**  Stores the next available ID for new layers. This number is stored to prevent reuse of the same ID after layers have been removed. (since 1.2)
+   */
+  @:optional public var nextLayerId:Int;
+
   /** Properties of the map */
   @:optional public var properties:TmxProperties;// Map<String, String>;
   

--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -618,7 +618,7 @@ class TmxText
   public var strikeout:Bool;
   /** Whether kerning should be used while rendering the text (1) or not (0). Default to 1. */
   public var kerning:Bool;
-  /** Horizontal alignment of the text within the object (left (default), center or right) */
+  /** Horizontal alignment of the text within the object (left (default), center, right or justify (since Tiled 1.2.1)) */
   public var halign:TmxHAlign;
   /** Vertical alignment of the text within the object (top (default), center or bottom) */
   public var valign:TmxVAlign;
@@ -632,6 +632,7 @@ abstract TmxHAlign(String) from String to String
   var Left = "left";
   var Center = "center";
   var Right = "right";
+  var Justify = "justify";
 }
 
 @:enum

--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -321,7 +321,7 @@ enum TmxLayer
 class TmxGroup
 {
   /** Unique ID of the layer. Each layer that added to a map gets a unique id. Even if a layer is deleted, no layer ever gets the same ID. Can not be changed in Tiled. (since Tiled 1.2) */
-  @:optional public var id:Int;
+  public var id:Int;
   /** The name of the group layer. */
   public var name:String;
   /** Rendering offset of the group layer in pixels. Defaults to 0. */

--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -171,6 +171,7 @@ class Reader
     }
     
     return {
+      id: input.has.id ? Std.parseInt(input.att.id) : 0,
       name: input.att.name,
       offsetX: input.has.offsetx ? Std.parseInt(input.att.offsetx) : 0,
       offsetY: input.has.offsety ? Std.parseInt(input.att.offsety) : 0,

--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -66,6 +66,7 @@ class Reader
     
     return {
       version: map.att.version,
+      tiledVersion: map.has.tiledversion ? map.att.tiledversion : "",
       orientation: resolveOrientation(map.att.orientation),
       width: width,
       height: height,

--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -634,6 +634,7 @@ class Reader
     // Workaround to HaxeFoundation/haxe#6822
     var layer:TmxTileLayer = new TmxTileLayer(
       (input.hasNode.data ? resolveData(input.node.data) : null),
+      (input.has.id ? Std.parseInt(input.att.id) : 0),
       (input.has.name ? input.att.name : ""),
       (input.has.x ? Std.parseFloat(input.att.x) : 0),
       (input.has.y ? Std.parseFloat(input.att.y) : 0),
@@ -673,7 +674,7 @@ class Reader
       (input.has.draworder ? resolveDraworder(input.att.draworder) : TmxObjectGroupDrawOrder.Topdown),
       objects,
       (input.has.color ? Std.parseInt(input.att.color) : null),
-      
+      (input.has.id ? Std.parseInt(input.att.id) : 0),
       (input.has.name ? input.att.name : ""),
       (input.has.x ? Std.parseFloat(input.att.x) : 0),
       (input.has.y ? Std.parseFloat(input.att.y) : 0),
@@ -795,7 +796,7 @@ class Reader
   {
     var layer:TmxImageLayer = new TmxImageLayer(
       (input.hasNode.image ? resolveImage(input.node.image) : null),
-      
+      (input.has.id    ? Std.parseInt(input.att.id) : 0),
       (input.has.name    ? input.att.name : ""),
       (input.has.x       ? Std.parseFloat(input.att.x) : 0),
       (input.has.y       ? Std.parseFloat(input.att.y) : 0),

--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -80,6 +80,7 @@ class Reader
       staggerAxis: map.has.staggeraxis ? resolveStaggerAxis(map.att.staggeraxis) : null,
       hexSideLength: map.has.hexsidelength ? Std.parseInt(map.att.hexsidelength) : 0,
       nextObjectId: map.has.nextobjectid ? Std.parseInt(map.att.nextobjectid) : 0,
+      nextLayerId: map.has.nextlayerid ? Std.parseInt(map.att.nextlayerid): 0,
       infinite: map.has.infinite ? map.att.infinite == "1" : false
     };
   }

--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -735,7 +735,7 @@ class Reader
     }
     
     var object:TmxObject = {
-      id: Std.parseInt(obj.att.id), // if it's not here, you doing something wrong.
+      id: obj.has.id ? Std.parseInt(obj.att.id) : 0, // if it's not here, you doing something wrong.
       name: obj.has.name ? obj.att.name : "",
       type: obj.has.type ? obj.att.type : "",
       x: obj.has.x ? Std.parseFloat(obj.att.x) : 0,


### PR DESCRIPTION
To match up to tmx 1.2.1 format
- add nextLayerId, tiledVersion to `<map>`
- add id to `<layer>, <objectgroup>, <imagelayer> and <group>`
- add `justify` to `<text>` horizontal  align

Fixes
- fix object's id parsing in `.tx` (templates) files