### PR TITLE
update wang id to new format (since Tiled 1.5)

### DIFF
--- a/format/tmx/Data.hx
+++ b/format/tmx/Data.hx
@@ -214,10 +214,10 @@ class TmxWangSetTile
   /** The tile ID. */
   public var tileID:Int;
   /**
-   * The Wang ID, which is a 32-bit unsigned integer stored in the format 0xCECECECE
-   * (where each C is a corner color and each E is an edge color, from right to left clockwise, starting with the top edge)
+   * The Wang ID, given by a comma-separated list of indexes (starting from 1, because 0 means _unset_) referring to the 
+   * Wang colors in the Wang set in the following order: top, top right, right, bottom right, bottom, bottom left, left, top left.
    */
-  public var wangID:Int; // TODO: Abstract
+  public var wangID:String;
 }
 
 /**

--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -387,7 +387,7 @@ class Reader
     {
       tiles.push( {
         tileID: node.has.tileid ? Std.parseInt(node.att.tileid) : 0,
-        wangID: node.has.wangid ? Std.parseInt(node.att.wangid) : 0
+        wangID: node.has.wangid ? node.att.wangid : "0,0,0,0,0,0,0,0"
       });
     }
     


### PR DESCRIPTION
Tiled 1.5 changes wangid to a string with comma separated indexes (see https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#wangtile).