### PR TITLE
Allow only digits and commas as valid CSV data

### DIFF
--- a/format/tmx/Reader.hx
+++ b/format/tmx/Reader.hx
@@ -525,7 +525,9 @@ class Reader
           else
           {
             tiles = new Array();
-            var split:Array<String> = getRawData().split(",");
+            // Only allow digits and commas as valid data
+            var r = ~/[^\d,]/g;
+            var split:Array<String> = r.replace(getRawData(),'').split(",");
             for (str in split) tiles.push( new TmxTile(Std.parseInt(str)));
           }
         }


### PR DESCRIPTION
Allow only digits and commas as valid data in CSV.

Sometimes, Tiled saved the CSV data formatted with newline, e.g:

```xml
  <data encoding="csv">
34,34,34,34,34,34,34,34,34,
34,34,34,34,34,34,34,34,34,
34,34,34,34,34,34,34,34,34,
34,34,34,34,34,34,34,34,34,
...
</data>
```

Note there's a newline after each X values. Now the `Std.parseInt()` parses the number with newline as a zero, thus losing the information about the tile. This PR will remove all non-digits/commas characters before processing. 